### PR TITLE
fix(timestamps): avoid partial numeric matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ called against that piece of text.
 | **millis** | 13-digit Unix millisecond timestamps | Shows human-readable date/time |
 | **seconds** | 10-digit Unix second timestamps | Shows human-readable date/time |
 | **uuid** | UUIDs (v1–v7) | Shows UUID version info |
-| **hexcolor** | CSS hex colors (`#rrggbb`) | Shows RGB breakdown |
+| **hexcolor** | CSS hex colors (`#rgb`, `#rrggbb`, `#rrggbbaa`) | Shows RGB(A) breakdown + OKLCH |
 | **jwt** | JSON Web Tokens | Shows header info, subject, issuer, expiry |
 | **ipaddr** | IPv4 & IPv6 addresses | Shows address type (private/public/loopback) |
 | **base64** | Base64-encoded strings | Decodes and shows preview of content |

--- a/modules/millis/millis.go
+++ b/modules/millis/millis.go
@@ -11,7 +11,7 @@ import (
 	"github.com/taigrr/clipassist/matchers"
 )
 
-var millisRegex = regexp.MustCompile(`\d{13}`)
+var millisRegex = regexp.MustCompile(`\b\d{13}\b`)
 
 // Matchers returns a Matcher for 13-digit Unix millisecond timestamps.
 func Matchers() []matchers.Matcher {

--- a/modules/millis/millis_test.go
+++ b/modules/millis/millis_test.go
@@ -27,8 +27,10 @@ func TestMatchersRegexMatches13Digits(t *testing.T) {
 	}{
 		{"1234567890123", true},
 		{"0000000000000", true},
-		{"123456789012", false},  // 12 digits
-		{"12345678901234", true}, // 14 digits — contains a 13-digit substring
+		{"123456789012", false},
+		{"12345678901234", false},
+		{"ts=1234567890123", true},
+		{"1234567890123ms", false},
 		{"abcdef", false},
 	}
 

--- a/modules/seconds/seconds.go
+++ b/modules/seconds/seconds.go
@@ -11,7 +11,7 @@ import (
 	"github.com/taigrr/clipassist/matchers"
 )
 
-var secondsRegex = regexp.MustCompile(`\d{10}`)
+var secondsRegex = regexp.MustCompile(`\b\d{10}\b`)
 
 // Matchers returns a Matcher for 10-digit Unix timestamps.
 func Matchers() []matchers.Matcher {

--- a/modules/seconds/seconds_test.go
+++ b/modules/seconds/seconds_test.go
@@ -20,8 +20,10 @@ func TestSecondsRegex(t *testing.T) {
 		match bool
 	}{
 		{"1672531200", true},
-		{"123456789", false},  // 9 digits
-		{"12345678901", true}, // contains 10-digit substring
+		{"123456789", false},
+		{"12345678901", false},
+		{"ts=1672531200", true},
+		{"1672531200s", false},
 		{"abcdef", false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- require word boundaries for seconds and millis matchers so they don't fire on longer numeric strings
- add focused regression tests for embedded and suffixed timestamp cases
- refresh the README's hex color module description to match current behavior

## Testing
- go test ./...
- go test -race ./...
- staticcheck ./...
