### PR TITLE
refactor(matchers): return registry snapshots

### DIFF
--- a/matchers/matchers.go
+++ b/matchers/matchers.go
@@ -24,25 +24,32 @@ var (
 )
 
 func Get() []Matcher {
-	return matchers
+	matchLock.Lock()
+	defer matchLock.Unlock()
+
+	snapshot := make([]Matcher, len(matchers))
+	copy(snapshot, matchers)
+	return snapshot
 }
 
 func Add(a ...Matcher) {
 	matchLock.Lock()
+	defer matchLock.Unlock()
+
 	matchers = append(matchers, a...)
-	matchLock.Unlock()
 }
 
 func Remove(id string) {
-	toKeep := []Matcher{}
 	matchLock.Lock()
-	for _, m := range matchers {
-		if m.ID != id {
-			toKeep = append(toKeep, m)
+	defer matchLock.Unlock()
+
+	toKeep := make([]Matcher, 0, len(matchers))
+	for _, matcher := range matchers {
+		if matcher.ID != id {
+			toKeep = append(toKeep, matcher)
 		}
 	}
 	matchers = toKeep
-	matchLock.Unlock()
 }
 
 func Run(in string) {

--- a/matchers/matchers_test.go
+++ b/matchers/matchers_test.go
@@ -51,6 +51,26 @@ func TestRemoveNonExistent(t *testing.T) {
 	}
 }
 
+func TestGetReturnsSnapshot(t *testing.T) {
+	resetMatchers()
+	Add(Matcher{Regex: regexp.MustCompile(`a`), ID: "a", F: func(string) {}})
+
+	snapshot := Get()
+	snapshot[0].ID = "changed"
+	mutated := append(snapshot, Matcher{Regex: regexp.MustCompile(`b`), ID: "b", F: func(string) {}})
+	if len(mutated) != 2 {
+		t.Fatalf("expected mutated snapshot length 2, got %d", len(mutated))
+	}
+
+	got := Get()
+	if len(got) != 1 {
+		t.Fatalf("expected internal matcher list to stay length 1, got %d", len(got))
+	}
+	if got[0].ID != "a" {
+		t.Fatalf("expected internal matcher ID to remain %q, got %q", "a", got[0].ID)
+	}
+}
+
 func TestRunSubstringMatch(t *testing.T) {
 	resetMatchers()
 	var results []string


### PR DESCRIPTION
## Summary
- return a copied matcher slice from `Get()` instead of the live registry
- use deferred unlocks in matcher registry helpers
- add a regression test proving callers cannot mutate internal matcher state

## Testing
- go test -race ./...
- staticcheck ./...