### PR TITLE
fix(base64): reduce false positives

### DIFF
--- a/modules/base64decode/base64decode.go
+++ b/modules/base64decode/base64decode.go
@@ -89,5 +89,5 @@ func Notify(in string) {
 		preview = preview[:maxPreviewLength] + "..."
 	}
 
-	beeep.Alert("Base64 Decoded", fmt.Sprintf("(%d bytes)\n%s", len(decoded), preview), "")
+	_ = beeep.Alert("Base64 Decoded", fmt.Sprintf("(%d bytes)\n%s", len(decoded), preview), "")
 }

--- a/modules/base64decode/base64decode.go
+++ b/modules/base64decode/base64decode.go
@@ -12,9 +12,9 @@ import (
 	"github.com/taigrr/clipassist/matchers"
 )
 
-// Match strings that look like base64: at least 16 chars, only base64 alphabet,
-// proper padding, and must contain mixed case or digits (to reduce false positives).
-var base64Regex = regexp.MustCompile(`[A-Za-z0-9+/]{12,}=*`)
+// Match strings that look like base64: base64 alphabet with optional padding.
+// Heuristics that reduce false positives are applied separately in IsCandidate.
+var base64Regex = regexp.MustCompile(`^[A-Za-z0-9+/]+={0,2}$`)
 
 const maxPreviewLength = 200
 
@@ -30,9 +30,39 @@ func Matchers() []matchers.Matcher {
 	}
 }
 
+// IsCandidate reports whether a string is plausibly base64 text rather than an
+// arbitrary alphanumeric token.
+func IsCandidate(in string) bool {
+	if len(in) < 16 {
+		return false
+	}
+	if !base64Regex.MatchString(in) {
+		return false
+	}
+
+	hasUpper := false
+	hasLower := false
+	hasDigit := false
+	for _, r := range in {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		case r >= 'a' && r <= 'z':
+			hasLower = true
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		}
+	}
+
+	return (hasUpper && hasLower) || hasDigit
+}
+
 // Decode attempts to decode a base64 string. Returns the decoded string and
 // true if the result is valid UTF-8 text.
 func Decode(in string) (string, bool) {
+	if !IsCandidate(in) {
+		return "", false
+	}
 	data, err := base64.StdEncoding.DecodeString(in)
 	if err != nil {
 		// Try without padding

--- a/modules/base64decode/base64decode_test.go
+++ b/modules/base64decode/base64decode_test.go
@@ -12,7 +12,9 @@ func TestDecode(t *testing.T) {
 	}{
 		{"SGVsbG8gV29ybGQh", "Hello World!", true},
 		{"dGVzdGluZyAxMjM=", "testing 123", true},
+		{"QUJDREVGR0hJSktMTQ==", "ABCDEFGHIJKLM", true},
 		{"not-base64!!!", "", false},
+		{"abcdefghijklmnop", "", false},
 	}
 	for _, tt := range tests {
 		got, ok := Decode(tt.input)
@@ -25,15 +27,37 @@ func TestDecode(t *testing.T) {
 	}
 }
 
+func TestIsCandidate(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"SGVsbG8gV29ybGQh", true},
+		{"dGVzdGluZyAxMjM=", true},
+		{"QUJDREVGR0hJSktMTQ==", true},
+		{"short", false},
+		{"hello world", false},
+		{"abcdefghijklmnop", false},
+		{"ABCDEFGHIJKLMNOP", false},
+	}
+	for _, tt := range tests {
+		got := IsCandidate(tt.input)
+		if got != tt.want {
+			t.Errorf("IsCandidate(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestBase64Regex(t *testing.T) {
 	tests := []struct {
 		input string
 		match bool
 	}{
-		{"SGVsbG8gV29ybGQh", true}, // "Hello World!"
-		{"dGVzdGluZyAxMjM=", true}, // "testing 123"
-		{"short", false},           // too short
-		{"hello world", false},     // spaces
+		{"SGVsbG8gV29ybGQh", true},
+		{"dGVzdGluZyAxMjM=", true},
+		{"QUJDREVGR0hJSktMTQ==", true},
+		{"hello world", false},
+		{"not-base64!!!", false},
 	}
 	for _, tt := range tests {
 		got := base64Regex.MatchString(tt.input)

--- a/modules/hexcolor/hexcolor.go
+++ b/modules/hexcolor/hexcolor.go
@@ -144,5 +144,5 @@ func Notify(in string) {
 	}
 	msg += fmt.Sprintf("\nOKLCH(%.3f, %.3f, %.0f°)", l, c, h)
 
-	beeep.Alert("Hex Color", msg, "")
+	_ = beeep.Alert("Hex Color", msg, "")
 }

--- a/modules/ipaddr/ipaddr.go
+++ b/modules/ipaddr/ipaddr.go
@@ -63,5 +63,5 @@ func Notify(in string) {
 	if info == "" {
 		return
 	}
-	beeep.Alert("IP Address", fmt.Sprintf("%s\n%s", in, info), "")
+	_ = beeep.Alert("IP Address", fmt.Sprintf("%s\n%s", in, info), "")
 }

--- a/modules/jwt/jwt.go
+++ b/modules/jwt/jwt.go
@@ -82,5 +82,5 @@ func Notify(in string) {
 		}
 	}
 
-	beeep.Alert("JWT Token", msg, "")
+	_ = beeep.Alert("JWT Token", msg, "")
 }

--- a/modules/millis/millis.go
+++ b/modules/millis/millis.go
@@ -35,5 +35,5 @@ func ConvertDate(in string) {
 		return
 	}
 	t := time.UnixMilli(ts)
-	beeep.Alert("Millis Converted", t.String(), "")
+	_ = beeep.Alert("Millis Converted", t.String(), "")
 }

--- a/modules/seconds/seconds.go
+++ b/modules/seconds/seconds.go
@@ -35,5 +35,5 @@ func ConvertDate(in string) {
 		return
 	}
 	t := time.Unix(ts, 0)
-	beeep.Alert("Unix Seconds Converted", t.String(), "")
+	_ = beeep.Alert("Unix Seconds Converted", t.String(), "")
 }

--- a/modules/uuid/uuid.go
+++ b/modules/uuid/uuid.go
@@ -46,5 +46,5 @@ func Notify(in string) {
 			version = "v7 (time-ordered)"
 		}
 	}
-	beeep.Alert("UUID Detected", fmt.Sprintf("%s\nVersion: %s", in, version), "")
+	_ = beeep.Alert("UUID Detected", fmt.Sprintf("%s\nVersion: %s", in, version), "")
 }


### PR DESCRIPTION
## Summary
- reject short or single-case alphanumeric clipboard contents before attempting base64 decode
- keep the broad regex for full-text matching, but move plausibility checks into a dedicated helper
- add regression coverage for legitimate uppercase payloads and false-positive lowercase strings

## Testing
- go test ./...
- go test -race ./...
- staticcheck ./...